### PR TITLE
Added Post Type Param

### DIFF
--- a/commands/wpam-wp-cli-author-migrate.php
+++ b/commands/wpam-wp-cli-author-migrate.php
@@ -55,7 +55,7 @@ if ( ! class_exists( 'WPAM_WP_CLI_Author_Migrate' ) ) {
 
 			$post_types = isset( $assoc_args['post-type'] )
 				? $assoc_args['post-type']
-				: 'post';
+				: 'any';
 
 			try {
 				$cmd = new WPAM_Author_Migrate( $author_map, $default_author, $set_default, $post_types );

--- a/commands/wpam-wp-cli-author-migrate.php
+++ b/commands/wpam-wp-cli-author-migrate.php
@@ -18,6 +18,9 @@ if ( ! class_exists( 'WPAM_WP_CLI_Author_Migrate' ) ) {
 		 * [--set-default=<set-default>]
 		 * : Whether a default author should be set.
 		 *
+		 * [--post-type=<post_type>]
+		 * : The post types to convert. Can be a single post-type or multiple, comma-separated.
+		 *
 		 * ## Examples
 		 *
 		 * 	# Migrate using a remote author file.
@@ -27,13 +30,16 @@ if ( ! class_exists( 'WPAM_WP_CLI_Author_Migrate' ) ) {
 		 * 	wp wpam migrate ~/users.json
 		 *
 		 * 	# Migrate using a remote author file and set the default author to the user with an ID of 4.
-		 * 	wp wpam migrate https://example.com/users.json --default_author=4
+		 * 	wp wpam migrate https://example.com/users.json --default-author=4
 		 *
 		 * 	# Migrate using a remote author file and set the default author to the user with a username of "john".
-		 * 	wp wpam migrate https://example.com/users.json --default_author=john
+		 * 	wp wpam migrate https://example.com/users.json --default-author=john
 		 *
 		 * 	# Migrate using a remote author file and set the default author to the user with an email address of "john@example.com".
-		 * 	wp wpam migrate https://example.com/users.json --default_author=john@example.com
+		 * 	wp wpam migrate https://example.com/users.json --default-author=john@example.com
+		 *
+		 * # Migrate using a remote author file, set the default author to the user with an ID of 4 and process post types of `post` and `externalstory`.
+		 * wp wpam migrate https://example.com/users.json --default-author=4 --post-type=post,externalstory
 		 */
 		public function __invoke( $args, $assoc_args ) {
 			list( $author_map ) = $args;
@@ -47,8 +53,12 @@ if ( ! class_exists( 'WPAM_WP_CLI_Author_Migrate' ) ) {
 				? filter_var( $assoc_args['set-default'], FILTER_VALIDATE_BOOLEAN )
 				: true;
 
+			$post_types = isset( $assoc_args['post-type'] )
+				? $assoc_args['post-type']
+				: 'post';
+
 			try {
-				$cmd = new WPAM_Author_Migrate( $author_map, $default_author, $set_default );
+				$cmd = new WPAM_Author_Migrate( $author_map, $default_author, $set_default, $post_types );
 				$cmd->migrate();
 
 				WP_CLI::Success( $cmd->get_stats() );

--- a/includes/class-wpam-author-migrate.php
+++ b/includes/class-wpam-author-migrate.php
@@ -142,7 +142,7 @@ Unable to Update : $this->cannot_update
 			$invalid = array();
 			$throw = false;
 
-			// Short curcuit if the only parameter is 'all'
+			// Short curcuit if the only parameter is 'any'
 			if ( count( $this->post_types ) === 1 && $this->post_types[0] === 'any' ) {
 				return;
 			} else if ( in_array( 'any', $this->post_types ) ) {

--- a/includes/class-wpam-author-migrate.php
+++ b/includes/class-wpam-author-migrate.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WPAM_Author_Migrate' ) ) {
 		 * @param string $file_path The file path of the user export
 		 * @param mixed $default_user the username or ID of the default user.
 		 */
-		public function __construct( $file_path, $default_user=1, $set_default=True, $post_type='post' ) {
+		public function __construct( $file_path, $default_user=1, $set_default=True, $post_type='any' ) {
 			// Create empty arrays on author arrays
 			$this->all_authors      = array();
 			$this->authors          = array();
@@ -141,6 +141,17 @@ Unable to Update : $this->cannot_update
 		private function verify_post_types() {
 			$invalid = array();
 			$throw = false;
+
+			// Short curcuit if the only parameter is 'all'
+			if ( count( $this->post_types ) === 1 && $this->post_types[0] === 'any' ) {
+				return;
+			} else if ( in_array( 'any', $this->post_types ) ) {
+				// If we get here, there are multiple post_types defined
+				// but the `any` keyword is present.
+				// Update $this->post_types to be a single string.
+				$this->post_types = 'any';
+				return;
+			}
 
 			foreach( $this->post_types as $post_type ) {
 				if ( ! post_type_exists( $post_type ) ) {

--- a/includes/class-wpam-author-migrate.php
+++ b/includes/class-wpam-author-migrate.php
@@ -11,6 +11,7 @@ if ( ! class_exists( 'WPAM_Author_Migrate' ) ) {
 		public
 			$set_default_author, // Boolean that indicates if default author should be set.
 			$default_author,     // Default author object
+			$post_types,         // The post types to process
 			$all_authors,        // All authors encountered on new system
 			$authors,            // An array of authors
 			$unmapped_authors,   // Users with no local mapping
@@ -26,7 +27,7 @@ if ( ! class_exists( 'WPAM_Author_Migrate' ) ) {
 		 * @param string $file_path The file path of the user export
 		 * @param mixed $default_user the username or ID of the default user.
 		 */
-		public function __construct( $file_path, $default_user=1, $set_default=True ) {
+		public function __construct( $file_path, $default_user=1, $set_default=True, $post_type='post' ) {
 			// Create empty arrays on author arrays
 			$this->all_authors      = array();
 			$this->authors          = array();
@@ -39,6 +40,7 @@ if ( ! class_exists( 'WPAM_Author_Migrate' ) ) {
 			$this->cannot_update = 0;
 
 			$this->set_default_author = $set_default;
+			$this->post_types = array_map( 'trim', explode( ',', $post_type ) );
 
 			if ( $this->set_default_author ) {
 				$this->default_author = $this->get_default_author( $default_user );
@@ -71,7 +73,7 @@ if ( ! class_exists( 'WPAM_Author_Migrate' ) ) {
 		 */
 		public function migrate() {
 			$query = new WP_Query( array(
-				'post_type'      => 'post',
+				'post_type'      => $this->post_types,
 				'posts_per_page' => -1
 			) );
 

--- a/includes/class-wpam-author-migrate.php
+++ b/includes/class-wpam-author-migrate.php
@@ -42,6 +42,8 @@ if ( ! class_exists( 'WPAM_Author_Migrate' ) ) {
 			$this->set_default_author = $set_default;
 			$this->post_types = array_map( 'trim', explode( ',', $post_type ) );
 
+			$this->verify_post_types();
+
 			if ( $this->set_default_author ) {
 				$this->default_author = $this->get_default_author( $default_user );
 			}
@@ -128,6 +130,44 @@ Unable to Update : $this->cannot_update
 
 			return $retval;
 
+		}
+
+		/**
+		 * Helper function that verifies that the
+		 * provided post types exist.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 */
+		private function verify_post_types() {
+			$invalid = array();
+			$throw = false;
+
+			foreach( $this->post_types as $post_type ) {
+				if ( ! post_type_exists( $post_type ) ) {
+					$invalid[] = $post_type;
+					$throw = true;
+				}
+			}
+
+			if ( $throw ) {
+				$message = '';
+
+				if ( count( $invalid ) > 1 ) {
+					$post_types = "\"" . implode( "\", \"", array_slice( $invalid, 0, -1 ) ) . "\" and \"" . end( $invalid ) . "\"";
+
+					$message = "
+The post types $post_types are not valid post types
+on this WordPress instance.
+					";
+				} else {
+					$message = "
+The post type \"$invalid[0]\" is not a valid post type
+on this WordPress instance.
+					";
+				}
+
+				throw new Exception( $message );
+			}
 		}
 
 		/**


### PR DESCRIPTION
<!---
Thank you for contributing to WP-Author-Migration.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/WP-Author-Migration/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Added the `--post-type` parameter which allows for the post types to be converted to be defined. The default value is set to "all."

**Motivation and Context**
To allow flexibility in the way the plugin is used.

**How Has This Been Tested?**
The formatting and error handling have been tested locally. 

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [x] I have updated the documentation accordingly.
