### PR TITLE
Author mixup fix

### DIFF
--- a/includes/class-wpam-author-migrate.php
+++ b/includes/class-wpam-author-migrate.php
@@ -291,7 +291,7 @@ Alternatively, you can set no default user using --set-default=false
 			// Get the current post author
 			$current_author = (int)$post->post_author;
 
-			if ( ! isset( $this->all_authors[$current_author] && isset( $this->authors[$current_author] ) ) {
+			if ( ! isset( $this->all_authors[$current_author] ) && isset( $this->authors[$current_author] ) ) {
 				$this->all_authors[$current_author] = $this->authors[$current_author];
 			}
 

--- a/includes/class-wpam-author-migrate.php
+++ b/includes/class-wpam-author-migrate.php
@@ -291,8 +291,8 @@ Alternatively, you can set no default user using --set-default=false
 			// Get the current post author
 			$current_author = (int)$post->post_author;
 
-			if ( ! isset( $this->all_authors[$current_author] ) ) {
-				$this->all_authors[$current_author] = $current_author;
+			if ( ! isset( $this->all_authors[$current_author] && isset( $this->authors[$current_author] ) ) {
+				$this->all_authors[$current_author] = $this->authors[$current_author];
 			}
 
 			$author = isset( $this->authors[$current_author] )


### PR DESCRIPTION
<!---
Thank you for contributing to WP-Author-Migration.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/WP-Author-Migration/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Fixes the problem we saw with the author migration on Thursday. Basically, the conditional that checks to see if author needs to updated was always evaluating to true because what was being added to the all_authors array wasn't a `WPAM_Author` object but just the author_id. I think this was causing `$author` to be null, which was then causing the default author to be inserted instead. 

**Motivation and Context**
Bug Fix

**How Has This Been Tested?**
This has been verified by inspecting the arrays when running against production data locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
